### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/http.go
+++ b/http.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-// return host if has port in addr, or addr if missing port
+// HostOnly returns host if has port in addr, or addr if missing port
 func HostOnly(addr string) string {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
@@ -30,7 +30,7 @@ func CopyHeader(w http.ResponseWriter, r *http.Response) {
 	}
 }
 
-// Return http status text looks like "200 OK"
+// StatusText returns http status text looks like "200 OK"
 func StatusText(c int) string {
 	return fmt.Sprintf("%d %s", c, http.StatusText(c))
 }

--- a/server.go
+++ b/server.go
@@ -86,7 +86,7 @@ func (self *Server) Blocked(host string) bool {
 	return blocked
 }
 
-// HTTP proxy accepts requests with following two types:
+// ServeHTTP proxy accepts requests with following two types:
 //  - CONNECT
 //    Generally, this method is used when the client want to connect server with HTTPS.
 //    In fact, the client can do anything he want in this CONNECT way...


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?