### PR TITLE
Use `go install` instead of `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 HTTP/HTTPS proxy over SSH.
 
 ## Installation
-* Local machine: `go get github.com/justmao945/mallory/cmd/mallory`
+* Local machine: `go install github.com/justmao945/mallory/cmd/mallory@latest`
 * Remote server: need our old friend sshd
 
 ## Configuration


### PR DESCRIPTION
Go now uses `go install` to install packages like this one into GOBIN. `go get` is reserved for managing dependencies now. This is just a small docs change to reflect that.
